### PR TITLE
SWIG cleanup

### DIFF
--- a/extractor/describe.py
+++ b/extractor/describe.py
@@ -276,7 +276,7 @@ def describe_dna(s1, s2):
     s1_swig = util.swig_str(s1)
     s2_swig = util.swig_str(s2)
     extracted = extractor.extract(s1_swig[0], s1_swig[1],
-                                  s2_swig[0], s2_swig[1], 0)
+                                  s2_swig[0], s2_swig[1], extractor.TYPE_DNA)
 
     for variant in extracted.variants:
        # print(variant.type, variant.reference_start,

--- a/extractor/extractor.i
+++ b/extractor/extractor.i
@@ -21,86 +21,46 @@
 %module extractor
 %{
 #include "extractor.h"
-%} // extractor
+%}
 
 namespace std
 {
 %template(VariantVector) vector<mutalyzer::Variant>;
-} // std
+}
 
 namespace mutalyzer
 {
 
-// Version string for run-time identification.
-static char const* const VERSION = "2.2.0";
+static char const* const VERSION;
 
-// The character type used for all strings. For now it should just be
-// a char.
 typedef char char_t;
 
-// These constants can be used to specify the type of string to be
-// extracted. The extractor is primarily focussed on DNA/RNA. When
-// TYPE_PROTEIN (or another value) is used no complement string is
-// constructed and no reverse complement is calculated. For
-// TYPE_PROTEIN frame shift detection is applied on
-// deletions/insertions.
-static int const TYPE_DNA     = 0;
-static int const TYPE_PROTEIN = 1;
-static int const TYPE_OTHER   = 2;
+static int const TYPE_DNA;
+static int const TYPE_PROTEIN;
+static int const TYPE_OTHER;
 
-// These constants can be used to deterimine the type of variant.
-// Substitution covers most: deletions, insertions, substitutions, and
-// insertion/deletions. Indentity is used to describe the unchanged
-// (matched) regions. The constants are coded as bitfields and should
-// be appropriately combined, e.g., IDENTITY | TRANSPOSITION_OPEN for
-// describing a real transposition. Note that some combinations do NOT
-// make sense, e.g., SUBSTITUION | REVERSE_COMPLEMENT.
-static unsigned int const IDENTITY              = 0x01;
-static unsigned int const REVERSE_COMPLEMENT    = 0x02;
-static unsigned int const SUBSTITUTION          = 0x04;
-static unsigned int const TRANSPOSITION_OPEN    = 0x08;
-static unsigned int const TRANSPOSITION_CLOSE   = 0x10;
-static unsigned int const FRAME_SHIFT           = 0x20;
+static unsigned int const IDENTITY;
+static unsigned int const REVERSE_COMPLEMENT;
+static unsigned int const SUBSTITUTION;
+static unsigned int const TRANSPOSITION_OPEN;
+static unsigned int const TRANSPOSITION_CLOSE;
+static unsigned int const FRAME_SHIFT;
 
-static unsigned int const FRAME_SHIFT_NONE      = 0x00;
-static unsigned int const FRAME_SHIFT_1         = 0x01;
-static unsigned int const FRAME_SHIFT_2         = 0x02;
-static unsigned int const FRAME_SHIFT_REVERSE   = 0x04;
-static unsigned int const FRAME_SHIFT_REVERSE_1 = 0x08;
-static unsigned int const FRAME_SHIFT_REVERSE_2 = 0x10;
+static unsigned int const FRAME_SHIFT_NONE;
+static unsigned int const FRAME_SHIFT_1;
+static unsigned int const FRAME_SHIFT_2;
+static unsigned int const FRAME_SHIFT_REVERSE;
+static unsigned int const FRAME_SHIFT_REVERSE_1;
+static unsigned int const FRAME_SHIFT_REVERSE_2;
 
-// These constants are used in calculating the weight of the generated
-// description and consequently used to end the description process
-// when a certain ``trivial'' weight is exeeded. The weight constants
-// are based on their HGVS description lengths, i.e., the amount of
-// characters used.
-static size_t const WEIGHT_BASE               = 1; // i.e., A, G, T, C
-static size_t const WEIGHT_DELETION           = 3; // i.e., del
-static size_t const WEIGHT_DELETION_INSERTION = 6; // i.e., delins
-static size_t const WEIGHT_INSERTION          = 3; // i.e., ins
-static size_t const WEIGHT_INVERSION          = 3; // i.e., inv
-static size_t const WEIGHT_SEPARATOR          = 1; // i.e., _, [, ], ;
-static size_t const WEIGHT_SUBSTITUTION       = 1; // i.e., >
+static size_t const WEIGHT_BASE;
+static size_t const WEIGHT_DELETION;
+static size_t const WEIGHT_DELETION_INSERTION;
+static size_t const WEIGHT_INSERTION;
+static size_t const WEIGHT_INVERSION;
+static size_t const WEIGHT_SEPARATOR;
+static size_t const WEIGHT_SUBSTITUTION;
 
-// *******************************************************************
-// Variant structure
-//   This structure describes a variant (region of change).
-//
-//   @member reference_start: starting position of the variant within
-//                            the reference string
-//   @member reference_end: ending position of the variant within the
-//                          reference string
-//   @member sample_start: starting position of the variant within the
-//                         sample string
-//   @member sample_end: ending position of the variant within the
-//                       sample string
-//   @member type: type of the variant described using the
-//                 constants above
-//   @member transposition_start: starting position of a transposition
-//                                withing the reference string
-//   @member transposition_end: ending position of a transposition
-//                              withing the reference string
-// *******************************************************************
 struct Variant
 {
   size_t       reference_start;
@@ -110,38 +70,14 @@ struct Variant
   unsigned int type;
   size_t       transposition_start;
   size_t       transposition_end;
-}; // Variant
+};
 
-// *******************************************************************
-// Variant_List structure
-//   This structure describes a list of variants with associated
-//   metadata.
-//
-//   @member weight_position: weight used for position descriptors
-//   @member variants: vector of variants
-// *******************************************************************
 struct Variant_List
 {
   size_t               weight_position;
   std::vector<Variant> variants;
-}; // Variant_List
+};
 
-// *******************************************************************
-// extract function
-//   This function is the interface function for Python.
-//
-//   @arg reference: reference string
-//   @arg reference_length: length of the reference string
-//   @arg sample: sample string
-//   @arg sample_length: length of the sample string
-//   @arg type: type of strings  0 --- DNA/RNA (default)
-//                               1 --- Protein
-//                               2 --- Other
-//   @arg codon_string: serialized codon table: 64 characters
-//                      corresponding to the codons AAA, ..., TTT.
-//                      Only for protein extraction (frame shifts).
-//   @return: variant list with metadata
-// *******************************************************************
 Variant_List extract(char_t const* const reference,
                      size_t const        reference_length,
                      char_t const* const sample,
@@ -149,6 +85,4 @@ Variant_List extract(char_t const* const reference,
                      int const           type = TYPE_DNA,
                      char_t const* const codon_string = 0);
 
-} // mutalyzer
-
-#include "extractor.h"
+}

--- a/extractor/extractor.i
+++ b/extractor/extractor.i
@@ -152,4 +152,3 @@ Variant_List extract(char_t const* const reference,
 } // mutalyzer
 
 #include "extractor.h"
-

--- a/tests/test_extractor.py
+++ b/tests/test_extractor.py
@@ -13,8 +13,11 @@ class TestExtractor:
     def _test_dna(self, s1, s2, expected_variants):
         s1_swig = util.swig_str(s1)
         s2_swig = util.swig_str(s2)
-        extracted = extractor.extract(s1_swig[0], s1_swig[1], s2_swig[0], s2_swig[1], 0)
+        extracted = extractor.extract(s1_swig[0], s1_swig[1],
+                                      s2_swig[0], s2_swig[1], extractor.TYPE_DNA)
+
         assert len(extracted.variants) == len(expected_variants)
+
         for variant, expected_variant in zip(extracted.variants, expected_variants):
             for attribute, expected_value in expected_variant.items():
                 assert getattr(variant, attribute) == expected_value


### PR DESCRIPTION
Here is some cleanup in the SWIG interface file, which had too much definitions and comments leading to a lot of duplication. Both comments and definitions where in some cases out-of-sync with the C++ header file, so I think it's better to keep the SWIG interface file as minimal as possible.

I also changed the Python code to use constant definitions from the extractor instead of their raw values.

@jkvis I would also suggest to remove the library version ("revision") from the comment blocks at the top of all files and just stick with the `VERSION` definition in the C++ header file to prevent these running out-of-sync. I didn't touch that now since you might be opinionated on it.

**Note**: These changes are on top of #4 so please merge that one first.
