### PR TITLE
Abort after exceeding run time limit

### DIFF
--- a/extractor/extractor.h
+++ b/extractor/extractor.h
@@ -23,6 +23,7 @@
 #include <cstddef>
 #include <cstdlib>
 #include <vector>
+#include <stdexcept>
 
 
 #if defined(__debug__)
@@ -135,6 +136,17 @@ extern uint8_t frame_shift_map[128][128][128];
 // combinations of two amino acids (indexed by the lower 127 ASCII
 // characters). Used to calculate the frame shift probability.
 extern uint8_t frame_shift_count[128][128][5];
+
+// Exception raised when run time is exceeded.
+class RunTimeException: public std::exception {
+ public:
+    explicit RunTimeException(const char* inMessage);
+    virtual ~RunTimeException() throw() {}
+    virtual const char* what() const throw();
+    const char* message() const;
+ private:
+    const char* mMessage;
+};
 
 // *******************************************************************
 // Variant structure
@@ -707,4 +719,3 @@ size_t Dprint_truncated(char_t const* const string,
 } // mutalyzer
 
 #endif
-

--- a/extractor/extractor.i
+++ b/extractor/extractor.i
@@ -17,10 +17,32 @@
 // *******************************************************************
 
 %include "std_vector.i"
+%include "exception.i"
 
 %module extractor
 %{
 #include "extractor.h"
+static PyObject* pRunTimeException;
+%}
+
+%init %{
+    pRunTimeException = PyErr_NewException("_extractor.RunTimeException", NULL, NULL);
+    Py_INCREF(pRunTimeException);
+    PyModule_AddObject(m, "RunTimeException", pRunTimeException);
+%}
+
+%exception {
+    try {
+        $action
+    }
+    catch (const mutalyzer::RunTimeException & e) {
+        PyErr_SetString(pRunTimeException, const_cast<char*>(e.what()));
+        return NULL;
+    }
+}
+
+%pythoncode %{
+    RunTimeException = _extractor.RunTimeException
 %}
 
 namespace std


### PR DESCRIPTION
This is a very quick and dirty test to see how we can work with C++ exceptions in Python land.

It defines a custom exception type, and a Python wrapper for it. When the exception is thrown, I can catch the Python wrapper at the Python side and extract the message.

For @jkvis:
- [ ] I'm using plain `char*` for the message, most examples online use `std::string`. I have no idea why to prefer one over the other here. Please choose something.
- [ ] Not sure if `RunTimeException` is the best name.
- [ ] We should make the time limit a parameter.
- [ ] Perhaps the check can be slightly more sophisticated, but we can test how this performs.
- [ ] And please go over the C++ code I added carefully, since I'm really not much of a C++ programmer! :sweat:

For @martijnvermaat:
- [ ] Some unit tests.
- [ ] The exception message is a bytestring on Python 2.7, not unicode. I should probably fix this with some wrapper.
