### PR TITLE
Fix setup.py to always run SWIG before copying generated files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,5 @@ before_install:
   - sudo apt-get install -y swig
   - pip install pytest
 install:
-  - pip install .
+  - python setup.py install
 script: py.test


### PR DESCRIPTION
We had some weird issues where running `python setup.py install` did not
correctly install the SWIG generated file. Apparently some steps where
not done in the correct order.

Installing with `python setup.py develop`, or `pip install .`, or with
pip directly from PyPI would work fined, as would running the regular
`python setup.py install` twice.

A similar issue was filed for WND-CHARM [1] and on Python distutils [2].
We implement the workaround provided in [3].

[1] https://github.com/wnd-charm/wnd-charm/issues/3
[2] http://bugs.python.org/issue7562
[3] http://stackoverflow.com/questions/12491328/python-distutils-not-include-the-swig-generated-module
