### PR TITLE
Don't require a specific BioPython version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -79,5 +79,5 @@ setup(
         'Topic :: Scientific/Engineering',
     ],
     keywords='bioinformatics',
-    install_requires=['biopython==1.65']
+    install_requires=['biopython']
 )


### PR DESCRIPTION
It's not necessary to pin the BioPython dependency on a specific
version, but it may result in issues with dependency resolving in
projects using the description extractor.

http://python-packaging-user-guide.readthedocs.org/en/latest/requirements/
